### PR TITLE
Make the mkdir invocation compatible with Windows

### DIFF
--- a/commands/slugs/download.js
+++ b/commands/slugs/download.js
@@ -14,7 +14,7 @@ function* run (context, heroku) {
     id = releases.filter((r) => r.slug)[0].slug.id
   }
   let slug = yield heroku.request({path: `/apps/${context.app}/slugs/${id}`})
-  exec(`mkdir -p ${context.app}`)
+  exec(`mkdir ${context.app}`)
   yield download(slug.blob.url, `${context.app}/slug.tar`, {progress: true})
   exec(`tar -xf ${context.app}/slug.tar -C ${context.app}`)
 }


### PR DESCRIPTION
This prevent a superfluous directory with name `-p` being created on Windows, where `mkdir.exe` does not support the `-p` option. The option is redundant, since the directory's parent will always exist.

Fixes #5.