### PR TITLE
Give downloaded slug the correct file extension

### DIFF
--- a/commands/slugs/download.js
+++ b/commands/slugs/download.js
@@ -15,14 +15,14 @@ function* run (context, heroku) {
   }
   let slug = yield heroku.request({path: `/apps/${context.app}/slugs/${id}`})
   exec(`mkdir ${context.app}`)
-  yield download(slug.blob.url, `${context.app}/slug.tar`, {progress: true})
+  yield download(slug.blob.url, `${context.app}/slug.tar.gz`, {progress: true})
   exec(`tar -xf ${context.app}/slug.tar -C ${context.app}`)
 }
 
 module.exports = {
   topic: 'slugs',
   command: 'download',
-  description: 'downloads a slug to slug.dump',
+  description: 'downloads a slug to <APP_NAME>/slug.tar.gz and then extracts it',
   help: 'If SLUG_ID is not specified, returns the current slug.',
   args: [{name: 'slug_id', optional: true}],
   needsApp:  true,


### PR DESCRIPTION
The slug is a gzipped tar file, rather than a plain tar archive.

Fixes #4. The usage text has also been updated to fix #7.