### PR TITLE
Bump version to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroku-slugs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Heroku CLI Plugin to manage and download slugs",
   "main": "index.js",
   "author": "Jeff Dickey @dickeyxxx",


### PR DESCRIPTION
Changes since the last release:
* The downloaded slug is now given the correct extension (`.tar.gz`).
* Extraction no longer creates a spurious `-p` directory on Windows.