### PR TITLE
Honor HEROKU_HTTP_PROXY_* settings when downloading slug from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ $ heroku slugs:download 00000000-bbbb-cccc-dddd-eeeeeeeeeeee -a appname
 ```
 
 This will download the Slug directly from our filestore on S3
+
+## Using a proxy
+
+```
+$ export HEROKU_HTTP_PROXY_HOST=<your-proxy-host>
+$ export HEROKU_HTTP_PROXY_PORT=<your-proxy-port>
+$ heroku slugs:download 00000000-bbbb-cccc-dddd-eeeeeeeeeeee -a appname
+```

--- a/lib/download.js
+++ b/lib/download.js
@@ -2,6 +2,7 @@ let fs          = require('fs')
 let https       = require('https')
 let progress    = require('smooth-progress')
 let bytes       = require('bytes')
+let tunnel      = require('tunnel-agent')
 
 function showProgress (rsp) {
   let bar = progress({
@@ -19,13 +20,29 @@ function showProgress (rsp) {
 function download(url, path, opts) {
   return new Promise(function (fulfill, reject) {
     let file = fs.createWriteStream(path)
-    https.get(url, function (rsp) {
+    let agent = makeAgent()
+
+    https.get(url, { agent }, function (rsp) {
       if (opts.progress) showProgress(rsp)
       rsp.pipe(file)
       .on('error', reject)
       .on('close', fulfill);
     })
   })
+}
+
+function makeAgent() {
+  let host = process.env.HEROKU_HTTP_PROXY_HOST
+
+  if (!host) {
+    return
+  }
+
+  let port = process.env.HEROKU_HTTP_PROXY_PORT || 8080
+  let auth = process.env.HEROKU_HTTP_PROXY_AUTH
+  let opts = { proxy: { host, port, proxyAuth: auth } }
+
+  return tunnel.httpsOverHttp(opts)
 }
 
 module.exports = download


### PR DESCRIPTION
## Why the change?

Currently this command honors `HEROKU_HTTP_PROXY_` env vars when it talks to the Heroku API but *not* when it downloads the slug from S3. This PR adds proxy support to the download step.

## How do I verify this?

1. Check out the branch
2. Link it to your heroku CLI:
   ```
   heroku plugins:link <path-to-repo>
   ```
3. Boot up a proxy of some kind (I used [mitmproxy](https://mitmproxy.org))
4. Download a slug using the proxy:
   ```
   HEROKU_HTTP_PROXY_HOST=<your-proxy-host> \
   HEROKU_HTTP_PROXY_PORT=<your-proxy-port> \
   heroku slugs:download -a <your-app> <slug-uuid>
   ```
7. Verify that the slug downloads correctly and requests go via the proxy
8. Download a slug without the proxy:
   ```
   heroku slugs:download -a <your-app> <slug-uuid>
   ```
9. Verify that the slug downloads correctly

## How do I do all that with mitmproxy?

1. Install mitmproxy:
   ```
   brew install mitmproxy
   ```
2. Boot it up:
   ```
   mitmweb --set stream_large_bodies=4k
   ```
3. Open **System preferences** and click your way to **Network > Advanced > Proxies > Web Proxy**
4. Enable “Web proxy (HTTP)” and set it to `localhost:8080`.
5. Visit [http://mitm.it](http://mitm.it)
6. Download the certificate but don’t worry about the rest of the instructions (these don’t apply for Node)
7. Disable “Web proxy (HTTP)”
8. Download a slug using the proxy:
   ```
   NODE_EXTRA_CA_CERTS=<path-to-the-cert> \
   HEROKU_HTTP_PROXY_HOST=localhost \
   HEROKU_HTTP_PROXY_PORT=8080 \
   heroku slugs:download -a <your-app> <slug-uuid>
   ```
9. Verify that the slug downloads correctly and requests go via the proxy
10. Download a slug without the proxy:
    ```
    heroku slugs:download -a <your-app> <slug-uuid>
    ```
11. Verify that the slug downloaded correctly

## Why not use global-agent?

global-agent expects a single env var (with host and port) whereas the existing heroku-client expects two separate env vars. It seemed overall simpler to rig things up to match the existing heroku-client behavior.