### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
     patch-dependencies:
       update-types:
         - "patch"
+  ignore:
+    - dependency-name: "@oclif/core"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "typescript"
+      update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,18 @@ updates:
   directory: "/"
   open-pull-requests-limit: 10
   schedule:
-    interval: "weekly"
+      interval: "weekly"
+      time: "12:00"
+      day: "sunday"
+      timezone: "America/Los_Angeles"
 - package-ecosystem: "npm"
   directory: "/"
   open-pull-requests-limit: 10
   schedule:
-    interval: "daily"
+      interval: "weekly"
+      time: "12:00"
+      day: "sunday"
+      timezone: "America/Los_Angeles"
   groups:
     dev-deps:
       dependency-type: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  open-pull-requests-limit: 10
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "npm"
+  directory: "/"
+  open-pull-requests-limit: 10
+  schedule:
+    interval: "daily"
+  groups:
+    dev-deps:
+      dependency-type: "development"
+    patch-dependencies:
+      update-types:
+        - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
 - package-ecosystem: "github-actions"
   directory: "/"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5
   schedule:
       interval: "weekly"
       time: "12:00"
@@ -10,7 +10,7 @@ updates:
       timezone: "America/Los_Angeles"
 - package-ecosystem: "npm"
   directory: "/"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5
   schedule:
       interval: "weekly"
       time: "12:00"


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000023dE14YAE/view

New dependabot.yml configuration. It will:
* check github action updates as well as npm
* set the schedule for fetching dependabots for weekly.
* group devdependencies if it can
* group patch updates if it can
* ignore major updates to typescript and oclif/core